### PR TITLE
add s390x compatibility

### DIFF
--- a/containers/web/Dockerfile
+++ b/containers/web/Dockerfile
@@ -5,7 +5,7 @@
 # *
 
 # Dockerfile for NodeJS application portion
-FROM node:latest
+FROM S390x/node:latest
 
 # Create the directory for the app
 RUN mkdir -p "/usr/src/app"


### PR DESCRIPTION
DO NOT MERGE; this branch should be preserved for use in coming years if you should decide to run OED on a linux machine!

# Description

The OED web application is now s390x compatible; it can be hosted and run on the IBM linuxONE or Z mainframes if you have access to those.  we did it !  it was node that was messing everything up.  This commit marks OED's ability to run on the s390x architecture!

Fixes #

There is no particular issue fixed here; just s390x compatibility.

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [x] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

Because of node, this is not cross-compatible; you need different web containers to run on different architectures.  Fully integrating node into s390x would be necessary to fix that, but I don't believe the architecture allows for such a thing.
