### PR TITLE
Update Dockerfile

### DIFF
--- a/containers/web/Dockerfile
+++ b/containers/web/Dockerfile
@@ -5,6 +5,9 @@
 # *
 
 # Dockerfile for NodeJS application portion
+# for use with the s390x architecture, replace line 11 with line 10:
+
+# FROM s390x/node:latest
 FROM node:latest
 
 # Create the directory for the app


### PR DESCRIPTION
Description

The OED web application is now s390x compatible; it can be hosted and run on the IBM linuxONE or Z mainframes if you have access to those. we did it ! it was node that was messing everything up. This commit marks OED's ability to run on the s390x architecture!

Fixes #

This fixes s390x compatibility; a line of code can be changed for it to work on any architecture.  This change is reflected in the s390x branch.

Type of change

Note merging this changes the node modules
Note merging this changes the database configuration.

    This change requires a documentation update

Checklist

I have followed the OED pull request ideas

    I have removed text in ( ) from the issue request

Limitations

Because of node, this is not cross-compatible; you need different web containers to run on different architectures. Fully integrating node into s390x would be necessary to fix that, but I don't believe the architecture allows for such a thing.  Which is why I added code in the comments.  Let me know what you think!